### PR TITLE
Feature webvtt

### DIFF
--- a/src/iso_boxer.js
+++ b/src/iso_boxer.js
@@ -9,11 +9,41 @@ ISOBoxer.Utils.dataViewToString = function(dataView, encoding) {
   if (typeof TextDecoder !== 'undefined') {
     return new TextDecoder(encoding || 'utf-8').decode(dataView);
   }
-  var str = '';
-  for (var i=0; i<dataView.byteLength; i++) {
-    str += String.fromCharCode(dataView.getUint8(i));
-  }    
-  return str;  
+  var a = [];
+  var i = 0;
+  if (encoding === 'utf-8') {
+      /* The following algorithm is essentially a rewrite of the UTF8.decode at 
+      http://bannister.us/weblog/2007/simple-base64-encodedecode-javascript/
+      */
+      
+      while (i < dataView.byteLength) {
+          var c = dataView.getUint8(i++);
+          if (c < 0x80) {
+              // 1-byte character (7 bits)
+          } else if (c < 0xe0) {
+              // 2-byte character (11 bits)
+              c = (c & 0x1f) << 6;
+              c |= (dataView.getUint8(i++) & 0x3f);
+          } else if (c < 0xf0) {
+              // 3-byte character (16 bits)
+              c = (c & 0xf) << 12;
+              c |= (dataView.getUint8(i++) & 0x3f) << 6;
+              c |= (dataView.getUint8(i++) & 0x3f);
+          } else {
+              // 4-byte character (21 bits)
+              c = (c & 0x7) << 18;
+              c |= (dataView.getUint8(i++) & 0x3f) << 12;
+              c |= (dataView.getUint8(i++) & 0x3f) << 6;
+              c |= (dataView.getUint8(i++) & 0x3f);
+          }
+          a.push(String.fromCharCode(c));
+      }
+  } else { // Just map byte-by-byte (probably wrong)
+      while (i < dataView.byteLength) {
+          a.push(String.fromCharCode(dataView.getUint8(i)));
+      }
+  }
+  return a.join('');  
 };
 
 if (typeof exports !== 'undefined') {

--- a/src/parsers/dinf,edts,mdia,meco,mfra,minf,moof,moov,mvex,stbl,strk,traf,trak,tref,udta,vttc.js
+++ b/src/parsers/dinf,edts,mdia,meco,mfra,minf,moof,moov,mvex,stbl,strk,traf,trak,tref,udta,vttc.js
@@ -1,7 +1,7 @@
-// Simple container boxes, all from ISO/IEC 14496-12:2012
+// Simple container boxes, all from ISO/IEC 14496-12:2012 except vttc which is from 14496-30.
 [
   'moov', 'trak', 'tref', 'mdia', 'minf', 'stbl', 'edts', 'dinf',
-  'mvex', 'moof', 'traf', 'mfra', 'udta', 'meco', 'strk'
+  'mvex', 'moof', 'traf', 'mfra', 'udta', 'meco', 'strk', 'vttc'
 ].forEach(function(boxType) {
   ISOBox.prototype._boxParsers[boxType] = function() {
     this.boxes = [];

--- a/src/parsers/payl.js
+++ b/src/parsers/payl.js
@@ -1,0 +1,5 @@
+// ISO/IEC 14496-30:2014 - WebVTT Cue Payload Box. Return ArrayBuffer
+ISOBox.prototype._boxParsers['payl'] = function() {
+  this.cue_text_raw = new DataView(this._raw.buffer, this._cursor.offset, this._raw.byteLength - (this._cursor.offset - this._offset));
+  this.cue_text = ISOBoxer.Utils.dataViewToString(this.cue_text_raw, 'utf-8');
+}

--- a/src/parsers/payl.js
+++ b/src/parsers/payl.js
@@ -1,5 +1,5 @@
-// ISO/IEC 14496-30:2014 - WebVTT Cue Payload Box. Return ArrayBuffer
+// ISO/IEC 14496-30:2014 - WebVTT Cue Payload Box.
 ISOBox.prototype._boxParsers['payl'] = function() {
-  this.cue_text_raw = new DataView(this._raw.buffer, this._cursor.offset, this._raw.byteLength - (this._cursor.offset - this._offset));
-  this.cue_text = ISOBoxer.Utils.dataViewToString(this.cue_text_raw, 'utf-8');
+  var cue_text_raw = new DataView(this._raw.buffer, this._cursor.offset, this._raw.byteLength - (this._cursor.offset - this._offset));
+  this.cue_text = ISOBoxer.Utils.dataViewToString(cue_text_raw, 'utf-8');
 }

--- a/src/parsers/vlab.js
+++ b/src/parsers/vlab.js
@@ -1,5 +1,5 @@
 // ISO/IEC 14496-30:2014 - WebVTT Source Label Box
 ISOBox.prototype._boxParsers['vlab'] = function() {
-  this.source_label_raw = new DataView(this._raw.buffer, this._cursor.offset, this._raw.byteLength - (this._cursor.offset - this._offset));
-  this.source_label = ISOBoxer.Utils.dataViewToString(this.source_label_raw, 'utf-8');
+  var source_label_raw = new DataView(this._raw.buffer, this._cursor.offset, this._raw.byteLength - (this._cursor.offset - this._offset));
+  this.source_label = ISOBoxer.Utils.dataViewToString(source_label_raw, 'utf-8');
 }

--- a/src/parsers/vlab.js
+++ b/src/parsers/vlab.js
@@ -1,0 +1,5 @@
+// ISO/IEC 14496-30:2014 - WebVTT Source Label Box
+ISOBox.prototype._boxParsers['vlab'] = function() {
+  this.source_label_raw = new DataView(this._raw.buffer, this._cursor.offset, this._raw.byteLength - (this._cursor.offset - this._offset));
+  this.source_label = ISOBoxer.Utils.dataViewToString(this.source_label_raw, 'utf-8');
+}

--- a/src/parsers/vttC.js
+++ b/src/parsers/vttC.js
@@ -1,5 +1,5 @@
 // ISO/IEC 14496-30:2014 - WebVTT Configuration Box
 ISOBox.prototype._boxParsers['vttC'] = function() {
-  this.config_raw = new DataView(this._raw.buffer, this._cursor.offset, this._raw.byteLength - (this._cursor.offset - this._offset));
-  this.config = ISOBoxer.Utils.dataViewToString(this.config_raw, 'utf-8');
+  var config_raw = new DataView(this._raw.buffer, this._cursor.offset, this._raw.byteLength - (this._cursor.offset - this._offset));
+  this.config = ISOBoxer.Utils.dataViewToString(config_raw, 'utf-8');
 }

--- a/src/parsers/vttC.js
+++ b/src/parsers/vttC.js
@@ -1,0 +1,5 @@
+// ISO/IEC 14496-30:2014 - WebVTT Configuration Box
+ISOBox.prototype._boxParsers['vttC'] = function() {
+  this.config_raw = new DataView(this._raw.buffer, this._cursor.offset, this._raw.byteLength - (this._cursor.offset - this._offset));
+  this.config = ISOBoxer.Utils.dataViewToString(this.config_raw, 'utf-8');
+}

--- a/src/parsers/vtte.js
+++ b/src/parsers/vtte.js
@@ -1,0 +1,4 @@
+// ISO/IEC 14496-30:2014 - Empty VTT sample
+ISOBox.prototype._boxParsers['vtte'] = function() {
+  // Nothing should happen here.
+}

--- a/src/parsers/vtte.js
+++ b/src/parsers/vtte.js
@@ -1,4 +1,4 @@
-// ISO/IEC 14496-30:2014 - Empty VTT sample
+// ISO/IEC 14496-30:2014 - WebVTT Empty Sample Box
 ISOBox.prototype._boxParsers['vtte'] = function() {
   // Nothing should happen here.
 }


### PR DESCRIPTION
In the implementation of support for segmented WebVTT in dash.js (https://github.com/Dash-Industry-Forum/dash.js/issues/992)  I needed an extension of the box parser to handle WebVTT sample data boxes. This is just the basic boxes.
As a separate commit, there is a better fallback UTF-8 converter. 