### PR TITLE
prevent oversize offset

### DIFF
--- a/src/iso_box.js
+++ b/src/iso_box.js
@@ -41,25 +41,60 @@ ISOBox.prototype._readUint = function(size) {
   var result = null;
   switch(size) {
   case 8:
-    result = this._raw.getUint8(this._cursor.offset - this._raw.byteOffset);
+    if(this._raw.byteLength <= (this._cursor.offset - this._raw.byteOffset))
+    {
+      result = 0;
+    }
+    else
+    {
+      result = this._raw.getUint8(this._cursor.offset - this._raw.byteOffset);
+    }
     break;
   case 16:
-    result = this._raw.getUint16(this._cursor.offset - this._raw.byteOffset);
+    if(this._raw.byteLength <= (this._cursor.offset - this._raw.byteOffset))
+    {
+      result = 0;
+    }
+    else
+    {
+      result = this._raw.getUint16(this._cursor.offset - this._raw.byteOffset);
+    }
     break;
   case 24:
-    var s1 = this._raw.getUint16(this._cursor.offset - this._raw.byteOffset);
-    var s2 = this._raw.getUint8(this._cursor.offset - this._raw.byteOffset + 2);
-    result = (s1 << 8) + s2;
+    if(this._raw.byteLength <= (this._cursor.offset - this._raw.byteOffset + 2))
+    {
+      result = 0;
+    }
+    else
+    {
+      var s1 = this._raw.getUint16(this._cursor.offset - this._raw.byteOffset);
+      var s2 = this._raw.getUint8(this._cursor.offset - this._raw.byteOffset + 2);
+      result = (s1 << 8) + s2;
+    }
     break;
   case 32:
-    result = this._raw.getUint32(this._cursor.offset - this._raw.byteOffset);
+    if(this._raw.byteLength <= (this._cursor.offset - this._raw.byteOffset))
+    {
+      result = 0;
+    }
+    else
+    {
+      result = this._raw.getUint32(this._cursor.offset - this._raw.byteOffset);
+    }
     break;
   case 64:
-    // Warning: JavaScript cannot handle 64-bit integers natively.
-    // This will give unexpected results for integers >= 2^53
-    var s1 = this._raw.getUint32(this._cursor.offset - this._raw.byteOffset);
-    var s2 = this._raw.getUint32(this._cursor.offset - this._raw.byteOffset + 4);
-    result = (s1 * Math.pow(2,32)) + s2;
+    if(this._raw.byteLength <= (this._cursor.offset - this._raw.byteOffset + 4))
+    {
+      result = 0;
+    }
+    else
+    {
+      // Warning: JavaScript cannot handle 64-bit integers natively.
+      // This will give unexpected results for integers >= 2^53
+      var s1 = this._raw.getUint32(this._cursor.offset - this._raw.byteOffset);
+      var s2 = this._raw.getUint32(this._cursor.offset - this._raw.byteOffset + 4);
+      result = (s1 * Math.pow(2,32)) + s2;
+    }
     break;
   }
   this._cursor.offset += (size >> 3);


### PR DESCRIPTION
Oversize offset were happen with every video taken from GoPro 4 Black 240fps mode. I didn't test with other GoPro mode but it still work fine with other video.

Here is a demo video. -> https://1drv.ms/v/s!Ak6c1464V4NG0MseCNZN_kqApoGTmA

A code I got an error.
```
function checkHiLight(videoPath, callback)
{
  var ISOBoxer    = require('codem-isoboxer');
  var arrayBuffer = new Uint8Array(fs.readFileSync(videoPath)).buffer;
  var parsedFile  = ISOBoxer.parseBuffer(arrayBuffer); // Error happen here.
  ....
  typeof callback === 'function' && callback();
}
```

Here was an error when I try to parse.
![image](https://cloud.githubusercontent.com/assets/13241662/17816084/89b875ac-6661-11e6-83fd-6baeba8e5670.png)

