### PR TITLE
Uint8Array.from support

### DIFF
--- a/src/iso_box.js
+++ b/src/iso_box.js
@@ -470,15 +470,24 @@ ISOBox.prototype._writeTemplate = function(size, value) {
 };
 
 ISOBox.prototype._writeData = function(data) {
+  var i;
   if (data instanceof Array) {
-    data = new DataView(Uint8Array.from(data).buffer);
+    if (!Uint8Array.from) {
+      var typedArray = new Uint8Array(data.length);
+      for (i = 0; i < data.length; i++) {
+        typedArray[i] = data[i];
+      }
+      data = new DataView(typedArray.buffer);
+    } else {
+      data = new DataView(Uint8Array.from(data).buffer);
+    }
   }
   if (data instanceof Uint8Array) {
     data = new DataView(data.buffer);
   }
   if (this._rawo) {
     var offset = this._cursor.offset - this._rawo.byteOffset;
-    for (var i = 0; i < data.byteLength; i++) {
+    for (i = 0; i < data.byteLength; i++) {
         this._rawo.setUint8(offset + i, data.getUint8(i));
     }
     this._cursor.offset += data.byteLength;


### PR DESCRIPTION
Add support for Uint8Array.from if not defined, like for example on IE11.